### PR TITLE
Update Getting-Started.md

### DIFF
--- a/go-filecoin-tutorial/Getting-Started.md
+++ b/go-filecoin-tutorial/Getting-Started.md
@@ -185,7 +185,7 @@ All balances of FIL are stored in wallets. When a node is newly created, it will
 
 During this initial sync time ther will be intense activity on one CPU core. Find out what the current block height is first by visiting the [network stats page](https://stats.testnet.filecoin.io) then observe the nodes syncing progress:
 ```sh
-watch -n 10 'go-filecoin show block $(go-filecoin chain head | head -n 1)'
+watch -n 10 "./go-filecoin show block $(./go-filecoin chain head | head -n 3|tail -n 1|awk '{print substr($0,9,62)}')"
 # Mac users will need to install watch first: brew install watch
 ````
 


### PR DESCRIPTION
./go-filecoin chain head | head -n 1 returns just "["
I tried ./go-filecoin chain head ,it returns:
[
	{
		"/": "bafy2bzacedajjxea4zfdef46bgqnntygqsmv6f2ntabrldkznpt7livxdmg6m"
	}
]
so, I written a script to get the right block.

after make, go-filecoin executable is in current directory, so we should add "./" as prefix.
I tested it in my macOS Mojave sucessfuly.