### PR TITLE
Initial commit for link updates

### DIFF
--- a/docs/advanced/README.md
+++ b/docs/advanced/README.md
@@ -33,6 +33,6 @@ $ ./venus-sealer actor control list
 
 ## Send funds from your addresses
 
-`venus-wallet` doesn't support sending funds from `cli`. Sending funds can be realized by exporting private key to a [wallet](https://docs.filecoin.io/about-filecoin/managing-assets/#wallets) that supports filecoin. And then send funds through the said wallet.
+`venus-wallet` doesn't support sending funds from `cli`. Sending funds can be realized by exporting private key to a [wallet](https://docs.filecoin.io/basics/assets/wallets/) that supports filecoin. And then send funds through the said wallet.
 
 Note that venus shared modules also blocks `send` messages for security reason, making your storage system more secure from potential attacks. This design makes sending funds less convienent but allows the seperation of an admin role and a node operator role for increased security. 

--- a/docs/zh/advanced/chain.md
+++ b/docs/zh/advanced/chain.md
@@ -25,17 +25,17 @@ Filecoin的区块链增长相对较快，因此完全同步将需要很长时间
 
 我们建议大多数用户从最小的轻量级快照执行初始节点同步。受信任状态快照不包含完整的链，并且可能不适合需要对历史状态信息执行查询的节点（例如区块浏览器），但对于大多数用户而言，它们是可行的。
 
-最近的最小受信任状态链快照在 [这里](https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car). 我们可以用venus启动守护程序并直接从URL导入：
+最近的最小受信任状态链快照在 [这里](https://snapshots.mainnet.filops.net/minimal/latest.zst). 我们可以用venus启动守护程序并直接从URL导入：
 
 ```sh
 # 快照大小约为7GiB。这适用于mainnet。
-venus daemon --import-snapshot https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car
+venus daemon --import-snapshot https://snapshots.mainnet.filops.net/minimal/latest.zst
 
 # 另一种方法是先下载并使用该文件
 venus daemon --import-snapshot <filename.car>
 
 # sha256sum 与临时快照一起存储，可以通过以下方式获取
-curl -sI https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car \
+curl -sI https://snapshots.mainnet.filops.net/minimal/latest.zst \
 | perl -ne '/^x-amz-website-redirect-location:(.+)\.car\s*$/ && print "$1.sha256sum"' \
 | xargs curl -s
 ```
@@ -72,7 +72,7 @@ venus chain head
 3. 如上所述，使用最小快照启动daemon:
 
   ```bash
-  venus daemon --import-snapshot https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car
+  venus daemon --import-snapshot https://snapshots.mainnet.filops.net/minimal/latest.zst
   ```
 
 在GitHub上[创建一个问题](https://github.com/filecoin-project/venus-docs/issues)。


### PR DESCRIPTION
Various changes have taken place on the docs.filecoin website and old links within Venus (and others) still point to these links. We are updating links across the Filecoin documentation ecosystem and this is the first PR against Venus. 