### PR TITLE
chore: bump version to v1.20.0 for docker build environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ dev:
 	npm run predownload
 	npm run docs:dev
 
-TAG:=v1.19.0
+TAG:=v1.20.0
 docker-buildenv:
 	docker build --build-arg https_proxy=$(BUILD_DOCKER_PROXY) -t filvenus/venus-buildenv:$(TAG) -f script/docker/venus-buildenv.dockerfile .
 	docker tag filvenus/venus-buildenv:$(TAG) filvenus/venus-buildenv:latest

--- a/script/docker/venus-buildenv.dockerfile
+++ b/script/docker/venus-buildenv.dockerfile
@@ -1,5 +1,5 @@
 # build container stage
-FROM golang:1.24-bookworm AS build-env
+FROM golang:1.25-bookworm AS build-env
 
 # RUN  sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list
 


### PR DESCRIPTION
## 变更内容

升级 Docker 构建环境以支持 venus v1.20.0：

### 改动清单

1. **script/docker/venus-buildenv.dockerfile** — Go 版本从 `1.24` 升级到 `1.25`
2. **Makefile** — TAG 从 `v1.19.0` 更新为 `v1.20.0`

### 背景

venus v1.20.0 的 go.mod 要求 Go >= 1.25.0，需要同步更新构建环境的基础镜像，否则 venus 仓库的 Docker 构建 CI 会因 Go 版本过低而失败。